### PR TITLE
Fixed non-showing loading indicator in processForm

### DIFF
--- a/ajax.js
+++ b/ajax.js
@@ -498,6 +498,8 @@ function processForm(vars) {
     xmlhttp.onreadystatechange = function stateChanged() {
         if (xmlhttp.readyState == 4) {
             document.getElementById("ajaxContentWindow").innerHTML = xmlhttp.responseText;
+            // Hide indicator icon
+            hidePopUp('indicatorDiv');
         }
     }
 
@@ -508,8 +510,6 @@ function processForm(vars) {
     //xmlhttp.setRequestHeader("Connection", "close"); // Commented out as not neccessary
     xmlhttp.send(vars);
 
-    // Hide indicator icon
-    hidePopUp('indicatorDiv');
 }
 
 function generateVars() {


### PR DESCRIPTION
"hidePopup" was called right after creating the AJAX request, but it should be called after the request finished e.g. in the method that handles the readyState 4. Otherwise the indicator would show, then the request created and the indicator hidden which leads to not showing the indicator at all in e.g. Chromium 48.
I noticed this bug when deleting huge directories which showed me no loading indicator.
